### PR TITLE
環境構築方法について

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_geometry
 )
 find_package(OpenCV REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 add_service_files(
   FILES
@@ -54,6 +55,7 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 link_directories(

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <depend>tf2_ros</depend>
   <depend>image_geometry</depend>
   <depend>libopencv-dev</depend>
+  <depend>eigen</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/rovi.rosinstall
+++ b/rovi.rosinstall
@@ -1,0 +1,24 @@
+- tar:
+    local-name: aravis
+    uri: http://ftp.gnome.org/pub/GNOME/sources/aravis/0.6/aravis-0.6.0.tar.xz
+    version: aravis-0.6.0
+- git:
+    local-name: camera_aravis
+    uri: http://github.com/YOODS/camera_aravis.git
+    version: master
+- git:
+    local-name: rosnodejs
+    uri: https://github.com/RethinkRobotics-opensource/rosnodejs
+    version: kinetic-devel
+- git:
+    local-name: rovi
+    uri: http://github.com/YOODS/rovi.git
+    version: israfel
+- git:
+    local-name: rovi_utils
+    uri: http://github.com/YOODS/rovi_utils.git
+    version: master
+- git:
+    local-name: rqt_param_manager
+    uri: https://github.com/YOODS/rqt_param_manager.git
+    version: devel


### PR DESCRIPTION
- 一般論ですが，環境構築は `wstool` と `rosdep` だけで行えるようにするのがよいと思います．https://github.com/YOODS/rovi/blob/israfel/Install.sh のように特殊な環境設定法に依存すると，このパッケージの環境設定に手間取ってしまう上に，他のソフトとインテグレーションして動かそうとしたときに，トラブルの原因になります．これはロボットソフトでは良くあるトラブル例ですが，ROSの良いところは，通信形式とかライブラリ以前に，この問題に着目して，誰が作ったパッケージでも同じ手順で開発環境を構築できる点にあると思っています．


　例：https://moveit.ros.org/install/source/
　例：https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_fetch_robot#setup-environment

- ただ実際には色々難しいところがあります．`aravis`, `python(pip)`, `npm`, `/etc/sysctl.conf`あたりが難しい点ですが, まずは一回おいておいて簡単なところから進めていきたいと思います．

- https://github.com/YOODS/rovi/commit/33bec142f6bac82f710ec5ec34d0a0231a1621e8 で rovi.rosinstall ファイルを作成しました．これで，
```
mkdir -p ws/src
cd ws/
wstool  init src
wstool merge -t src https://raw.github.com/k-okada/rovi/fix_install/rovi.rosinstall # mergeされたら修正する．
wstool update -t src #  Error processing 'aravis'  と表示されるが後で対処する．
rosdep install -y --from-paths src --ignore-src --rosdistro kinetic
```
で一通り環境設定が可能になります．
これでInstall.sh の以下の部分は代替出来ます．

https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L42
https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L60
https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L81

- Eigen について

以下で3.3.4をインストールしていますが，これは何か理由があるでしょうか？ apt で入る 3.3.-beat1-1(3.2.92) で足りない機能はなにになるでしょうか？簡単なところであれば3.3.4から必要な部分だけど，パッケージに含めるのが良いと思います．https://github.com/YOODS/rovi/commit/0633600ea2aac7a44147e622830e9a014a48daca も参照ください．

https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L46-L50

- pythonを含んだパッケージの開発について

以下でpythonのファイルをdevelスペースにコピーしていますが，`catkin_python_setup` の書き方に従って現状`lib/python2.7`以下にあるPythonのコードを`src/rovi_utils` 以下に置けば（3209e57），これらのファイルにアクセスできるようになるはずです．
http://docs.ros.org/jade/api/catkin/html/user_guide/setup_dot_py.html

https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L92

但し，この場合は既においてあるpythonのコードで
```
-import tflib
+from rovi_utils import tflib
 ```
と変更する必要があります(https://github.com/YOODS/rovi_utils/pull/10/commits/ad00db872f1639b352804641c4fad90d21692ffa)
ただ，この方が名前衝突も割けられますし良い変更かと思います．

- グローバルスペースへのスクリプトのインストールについて

以下で`rosrun ... `ではなく直接コマンドを打てばプログラムが立ち上がるようにしているかと思います．

https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L90

pythonのコードとしてみなせば，setup.pyに書いておくという方法があります．

https://github.com/ros-visualization/rqt/blob/da0b62e2995/rqt_gui/setup.py#L10

今回は
`tf_lookup.py`は既に書いてあるので，

https://github.com/YOODS/rovi_utils/blob/edd282462/setup.py#L9

これで，rosrun無しで動くようになっています．(インストールされている場所は /home/user/rovi_ws/devel/bin/tf_lookup.py)

もう一つは以下のようにcmakeの`install`コマンドを使う方法です．python以外場合はこちらを使うのが一般的です．

https://github.com/ros-visualization/rviz/blob/f9b357fdc0bfea5361e27b506059e62eab1f861b/src/rviz/CMakeLists.txt#L185-L186

こうすればdebファイルが作成されたときには，rosrun無しで実行できるパスにファイルがコピーされます．

開発中もこの環境をつくりたければ，`catkin build`の前でに`catkin config --install`とします（https://catkin-tools.readthedocs.io/en/latest/verbs/catkin_config.html ）ただ，この場合全てのパッケージできちんとcmakeの`install`命令を書かかないと行けなくなるので，ココは後回しにして先に進むのが良いと思います．（debファイルを作成する際にはこれは必須になります）

- aravisについて

`apt`では入らないライブラリを使った開発もROSでは対象になっており，幾つかの方法が試されています．（初期の例 http://wiki.ros.org/ROS/Tutorials/Wrapping%20External%20Libraries ) ，基本はライブラリのソースツリーに `package.xml` と `CMakeLists.txt` を置けばROSのパッケージと同じように開発環境に組み込むことが出来ます．

現状の`wstool update` はpythonの`tarfile`モジュールのバージョンから`tar.xz`に対応していないため
```
cd ~/ws/src
wget http://ftp.gnome.org/pub/GNOME/sources/aravis/0.6/aravis-0.6.0.tar.xz
tar -xvf aravis-0.6.0.tar.xz
```
として，このデレクトリの中に以下のファイルを置けば`catkin build`でコンパイル出来ます．
https://gist.github.com/d321b6fa8fd3503ba1e395b6651206c6

もう一つの方法はaravisのリリースリポジトリを作ることです．これは将来的にdebでリリースした際に必要になるものかとおもいます．やり方は http://wiki.ros.org/bloom/Tutorials/ReleaseThirdParty を参考にするのですが，aravis-release というリポジトリを作成し，そこに以下のファイルを追加します．

https://gist.github.com/a013458a4e0008b40fc1528ee98096d7

ただ，これは`tar.xz`がpython2では対応していないので，もし，ソースツリーをhttps://github.com/AravisProject/aravis/tree/ARAVIS_0_6_0
から持ってきてよければ，

https://gist.github.com/cfff59b21da0332f275ee2c74be8d20f

を利用します．

後はこのディレクトリで
```
git-bloom-release kinetic
```
とします，ここで，`git push --all && git push --tags` を行うよう指示がありますが，それをすると，`rovi.rosinstall`でこの以下の`debian/kinetic/xenial/aravis`ディレクトリを指定すると`package.xml`, `CMakeLists.txt`入りのソースツリーがダウンロードできます．

またここで，
```
git checkout debian/kinetic/xenial/aravis 
dpkg-buildpackage -rfakeroot -uc -b
```
とすると，debファイルも作成されます．

-  camera_aravisについて
上記の方法でaravisをインストールした場合は，以下のように変更してpkg-config 経由でaravisを見つけるのが楽かと思います．
https://github.com/YOODS/camera_aravis/pull/2

- python(pip)について

上に書いたように`rosdep install ...`として全ての必要なパッケージをインストールする，というコンセプトからすると，pipのパッケージについては以下のようにして`package.xml`にかいて`rosdep install`でインストールさせるというのがただいいやり方かと思います．
```
  <exec_depend version_eq="5.7" >ipython-pip</exec_depend>
  <exec_depend version_eq="4.10">ipykernel-pip</exec_depend> 
  <exec_depend>open3d-python-pip</exec_depend> 
```
新しいpipのパッケージについては以下のようにしてpull requestを出します．
https://github.com/ros/rosdistro/pull/21779

上のようにバージョン固定でインストールする方法についても以下でpull requestをだしました
https://github.com/ros-infrastructure/rosdep/pull/694
https://github.com/ros-infrastructure/rosdep/pull/693

ただ，これをしても/usr/local に入れたpythonのモジュールと他の人のアプリケーションがコンフリクトする，など問題が起こることは多々あるかと思います．

また，この方法でパッケージを作ってもdeb化した際にはpipのモジュールが含まれずに使いづらいものになるかと思います．

他のやり方としては
https://github.com/pyros-dev/catkin_pip　や https://github.com/locusrobotics/catkin_virtualenv
があります，こちらのほうがpipのインストール先がワークスペースに限られるなど，メリットがあるかもしれません．

- npm について

こちらもpipと同様でdeb化した際に問題になるので，可能であればpython/c等の言語でプログラムを書くことを強くおすすめしますが（あるいはjsのコード自体をパッケージに含める）
開発用に`rosdep install `でnpmもインストールできるようなpull requestを以下におきました．
https://github.com/ros-infrastructure/rosdep/pull/692

- あとは，/etc/sysctl.conf　ですが，

https://github.com/YOODS/rovi/blob/1f73606d6d50c629223d80f6a1adc8216b287a55/Install.sh#L19

非常にトリッキーな方法としてはコンパイル時に強制的に設定を追加する，という方法もありますが，
何れにせよ，debファイルを作成時には以下のようなファイルを作成してapt じに設定を書き換えることができます．

https://github.com/tork-a/jsk_3rdparty-release/blob/debian/kinetic/xenial/julius/debian/preinst
https://github.com/tork-a/minas/blob/master/minas_control/CMakeLists.txt#L42-L49

何れにせよupdate_sysctl.sh などのファイルを作成して`rosrun rovi update_sysctl.sh`などとさせるのが良いかと思います．

c.f. https://github.com/YOODS/rovi_utils/pull/10, https://github.com/YOODS/camera_aravis/pull/2