### PR TITLE
デスクトップエントリの修正

### DIFF
--- a/RoVI-SXGA.desktop
+++ b/RoVI-SXGA.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=RoVI(SXGA)
+Name=RoVI_SXGA
 Comment=
 Exec=rovirun.sh roslaunch rovi ycam3sxga.launch
 Icon=

--- a/RoVI-VGA.desktop
+++ b/RoVI-VGA.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=RoVI(SXGA)
+Name=RoVI_VGA
 Comment=
 Exec=rovirun.sh roslaunch rovi ycam3vga.launch
 Icon=


### PR DESCRIPTION
RoVI-SXGA.desktopを実行するとシンタックスエラーがでたので
Name=RoVI(SXGA)
を
Name=RoVI_SXGA
に変更しました
また、RoVI-VGA.desktopで
Name=RoVI(SXGA)
となっていたので
Name=RoVI_VGA
に変更しました